### PR TITLE
feat: sales items

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ function App() {
                 <li key={name}>
                   <div>{name}</div>
                   <div>{price}</div>
+                  <div>{sellable ? "구매 가능" : "구매 불가능"}</div>
                   <button disabled={!sellable}>구매</button>
                 </li>
               ))}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,16 @@
 import { ChangeIndicator } from "./class/ChangeIndicator";
+import { SalesItems } from "./class/SalesItems";
 import { useVendingMachine } from "./hook/useVendingMachine";
 import classNames from "classnames";
 import { useState } from "react";
 
 function App() {
   const vendingMachine = useVendingMachine({
+    salesItems: new SalesItems([
+      { name: "콜라", price: { value: 1100, currency: "원" }, stock: 0 },
+      { name: "물", price: { value: 600, currency: "원" }, stock: 10 },
+      { name: "커피", price: { value: 700, currency: "원" }, stock: 5 },
+    ]),
     changeIndicator: new ChangeIndicator(0, "원"),
   });
   const [actionLog] = useState<string[]>([]);
@@ -18,21 +24,13 @@ function App() {
           <section>
             <h3>판매 품목</h3>
             <ul className="flex gap-4">
-              <li>
-                <div>콜라</div>
-                <div>1,100원</div>
-                <button>구매</button>
-              </li>
-              <li>
-                <div>물</div>
-                <div>600원</div>
-                <button>구매</button>
-              </li>
-              <li>
-                <div>커피</div>
-                <div>700원</div>
-                <button>구매</button>
-              </li>
+              {vendingMachine.salesItems.map(({ name, price, sellable }) => (
+                <li key={name}>
+                  <div>{name}</div>
+                  <div>{price}</div>
+                  <button disabled={!sellable}>구매</button>
+                </li>
+              ))}
             </ul>
           </section>
 

--- a/src/class/SalesItems.ts
+++ b/src/class/SalesItems.ts
@@ -19,9 +19,6 @@ export class SalesItems {
     }));
   }
 
-  #getStockOf(product: Product["name"]) {
-    return this.#itemStock.get(product) || 0;
-  }
   hasStockOf(product: Product["name"]) {
     return this.#getStockOf(product) > 0;
   }
@@ -44,5 +41,9 @@ export class SalesItems {
 
       this.#itemStock.set(product, this.#getStockOf(product) - quantity);
     }
+  }
+
+  #getStockOf(product: Product["name"]) {
+    return this.#itemStock.get(product) ?? 0;
   }
 }

--- a/src/class/SalesItems.ts
+++ b/src/class/SalesItems.ts
@@ -1,0 +1,48 @@
+import { Product } from "../types/product";
+import autoBind from "auto-bind";
+
+export class SalesItems {
+  #items: Product[];
+  #itemStock = new Map<Product["name"], number>();
+
+  constructor(items: (Product & { stock: number })[]) {
+    autoBind(this);
+    this.#items = items.map(({ name, price }) => ({ name, price }) as Product);
+    items.forEach(({ name, stock }) => this.#itemStock.set(name, stock));
+  }
+
+  get list() {
+    return this.#items.map((item) => ({
+      name: item.name,
+      price: `${item.price.value}${item.price.currency}`,
+      stock: this.#getStockOf(item.name),
+    }));
+  }
+
+  #getStockOf(product: Product["name"]) {
+    return this.#itemStock.get(product) || 0;
+  }
+  hasStockOf(product: Product["name"]) {
+    return this.#getStockOf(product) > 0;
+  }
+  addItem(product: Product["name"], quantity: number) {
+    if (quantity < 0) {
+      throw new Error("수량은 0보다 작을 수 없습니다.");
+    }
+
+    this.#itemStock.set(product, this.#getStockOf(product) + quantity);
+  }
+  subtractItem(product: Product["name"], quantity: number) {
+    if (this.#itemStock.has(product)) {
+      if (quantity < 0) {
+        throw new Error("수량은 0보다 작을 수 없습니다.");
+      }
+
+      if (this.#getStockOf(product) < quantity) {
+        throw new Error("재고가 부족합니다.");
+      }
+
+      this.#itemStock.set(product, this.#getStockOf(product) - quantity);
+    }
+  }
+}

--- a/src/class/VendingMachine.ts
+++ b/src/class/VendingMachine.ts
@@ -1,19 +1,41 @@
+import { Product } from "../types/product";
 import { VendingMachine as IVendingMachine } from "../types/vendingMachine";
 import { ChangeIndicator } from "./ChangeIndicator";
+import { SalesItems } from "./SalesItems";
 import autoBind from "auto-bind";
 
 export interface VendingMachineParams {
+  salesItems: SalesItems;
   changeIndicator: ChangeIndicator;
 }
 export class VendingMachine implements IVendingMachine {
+  #salesItems;
   #changeIndicator;
 
-  constructor({ changeIndicator }: VendingMachineParams) {
+  constructor({ salesItems, changeIndicator }: VendingMachineParams) {
     autoBind(this);
+    this.#salesItems = salesItems;
     this.#changeIndicator = changeIndicator;
   }
 
+  get salesItems() {
+    return this.#salesItems.list.map((item) => ({
+      name: item.name,
+      price: item.price.toString(),
+      sellable: this.#checkSellable(item.name),
+    }));
+  }
   get changeValue() {
     return this.#changeIndicator.toString();
+  }
+
+  #checkSellable(product: Product["name"]) {
+    if (!this.#salesItems.hasStockOf(product)) {
+      return false;
+    }
+
+    //TODO - 보충 필요
+
+    return true;
   }
 }

--- a/src/hook/useVendingMachine.ts
+++ b/src/hook/useVendingMachine.ts
@@ -8,6 +8,7 @@ export const useVendingMachine = (
   const vendingMachine = useState(new VendingMachine(VendingMachineParams))[0];
   const captureVendingMachineSnapshot = (): IVendingMachine => ({
     changeValue: vendingMachine.changeValue,
+    salesItems: vendingMachine.salesItems,
   });
   const [vendingMachineSnapshot] = useState(captureVendingMachineSnapshot());
 

--- a/src/types/vendingMachine.ts
+++ b/src/types/vendingMachine.ts
@@ -1,3 +1,4 @@
 export interface VendingMachine {
+  salesItems: { name: string; price: string; sellable: boolean }[];
   changeValue: string;
 }


### PR DESCRIPTION
## 📝 Description

판매 물품을 다루는 class와 ui를 추가합니다.

## 🚀 Changes

- 판매 물품을 저장하는 SalesItems class 추가
- 판매 물품을 ui에 반영

## ⚠️ Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR includes a breakthrough change, please describe the impact on existing applications.
